### PR TITLE
gcc 6.3.0 default warnings removed

### DIFF
--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -1292,8 +1292,8 @@ ACMD(do_who)
         else if (PLR_FLAGGED(tch, PLR_WRITING))
           send_to_char(ch, " (writing)");
 
-      if (d->original)
-        send_to_char(ch, " (out of body)");
+        if (d->original)
+          send_to_char(ch, " (out of body)");
 
         if (d->connected == CON_OEDIT)
           send_to_char(ch, " (Object Edit)");
@@ -2044,14 +2044,15 @@ ACMD(do_toggle)
   }
 
   len = strlen(arg);
-  for (toggle = 0; *tog_messages[toggle].command != '\n'; toggle++)
+  for (toggle = 0; *tog_messages[toggle].command != '\n'; toggle++) {
     if (!strncmp(arg, tog_messages[toggle].command, len))
       break;
+  }
 
-    if (*tog_messages[toggle].command == '\n' || tog_messages[toggle].min_level > GET_LEVEL(ch)) {
-      send_to_char(ch, "You can't toggle that!\r\n");
-      return;
-    }
+  if (*tog_messages[toggle].command == '\n' || tog_messages[toggle].min_level > GET_LEVEL(ch)) {
+    send_to_char(ch, "You can't toggle that!\r\n");
+    return;
+  }
 
   switch (toggle) {
   case SCMD_COLOR:
@@ -2149,8 +2150,9 @@ ACMD(do_toggle)
         send_to_char(ch, "Okay, you'll now tough out fights to the bitter end.");
         GET_WIMP_LEV(ch) = 0;
       }
-    } else
+    } else {
       send_to_char(ch, "Specify at how many hit points you want to wimp out at.  (0 to disable)\r\n");
+    }
     break;
   case SCMD_PAGELENGTH:
     if (!*arg2)
@@ -2158,18 +2160,20 @@ ACMD(do_toggle)
     else if (is_number(arg2)) {
       GET_PAGE_LENGTH(ch) = MIN(MAX(atoi(arg2), 5), 255);
       send_to_char(ch, "Okay, your page length is now set to %d lines.", GET_PAGE_LENGTH(ch));
-    } else
+    } else {
       send_to_char(ch, "Please specify a number of lines (5 - 255).");
-      break;
+    }
+    break;
   case SCMD_SCREENWIDTH:
     if (!*arg2)
       send_to_char(ch, "Your current screen width is set to %d characters.", GET_SCREEN_WIDTH(ch));
     else if (is_number(arg2)) {
       GET_SCREEN_WIDTH(ch) = MIN(MAX(atoi(arg2), 40), 200);
       send_to_char(ch, "Okay, your screen width is now set to %d characters.", GET_SCREEN_WIDTH(ch));
-    } else
+    } else {
       send_to_char(ch, "Please specify a number of characters (40 - 200).");
-      break;
+    }
+    break;
   case SCMD_AUTOMAP:
     if (can_see_map(ch)) {
       if (!*arg2) {
@@ -2184,9 +2188,10 @@ ACMD(do_toggle)
         send_to_char(ch, "Value for %s must either be 'on' or 'off'.\r\n", tog_messages[toggle].command);
         return;
       }
-    } else
+    } else {
       send_to_char(ch, "Sorry, automap is currently disabled.\r\n");
-      break;
+    }
+    break;
   default:
     if (!*arg2) {
       TOGGLE_BIT_AR(PRF_FLAGS(ch), tog_messages[toggle].toggle);
@@ -2197,7 +2202,7 @@ ACMD(do_toggle)
     } else if (!strcmp(arg2, "off")) {
       REMOVE_BIT_AR(PRF_FLAGS(ch), tog_messages[toggle].toggle);
     } else {
-        send_to_char(ch, "Value for %s must either be 'on' or 'off'.\r\n", tog_messages[toggle].command);
+      send_to_char(ch, "Value for %s must either be 'on' or 'off'.\r\n", tog_messages[toggle].command);
       return;
     }
   }

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -3559,102 +3559,102 @@ ACMD (do_zcheck)
   send_to_char(ch, "Checking Mobs for limits...\r\n");
   /*check mobs first*/
   for (i=0; i<top_of_mobt;i++) {
-      if (real_zone_by_thing(mob_index[i].vnum) == zrnum) {  /*is mob in this zone?*/
-        mob = &mob_proto[i];
-        if (!strcmp(mob->player.name, "mob unfinished") && (found=1))
+    if (real_zone_by_thing(mob_index[i].vnum) == zrnum) {  /*is mob in this zone?*/
+      mob = &mob_proto[i];
+      if (!strcmp(mob->player.name, "mob unfinished") && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Alias hasn't been set.\r\n");
+
+      if (!strcmp(mob->player.short_descr, "the unfinished mob") && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Short description hasn't been set.\r\n");
+
+      if (!strncmp(mob->player.long_descr, "An unfinished mob stands here.", 30) && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Long description hasn't been set.\r\n");
+
+      if (mob->player.description && *mob->player.description) {
+        if (!strncmp(mob->player.description, "It looks unfinished.", 20) && (found=1))
           len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Alias hasn't been set.\r\n");
-
-        if (!strcmp(mob->player.short_descr, "the unfinished mob") && (found=1))
+                          "- Description hasn't been set.\r\n");
+        else if (strncmp(mob->player.description, "   ", 3) && (found=1))
           len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Short description hasn't been set.\r\n");
+                          "- Description hasn't been formatted. (/fi)\r\n");
+      }
 
-        if (!strncmp(mob->player.long_descr, "An unfinished mob stands here.", 30) && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Long description hasn't been set.\r\n");
+      if (GET_LEVEL(mob)>MAX_LEVEL_ALLOWED && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Is level %d (limit: 1-%d)\r\n",
+                        GET_LEVEL(mob), MAX_LEVEL_ALLOWED);
 
-        if (mob->player.description && *mob->player.description) {
-          if (!strncmp(mob->player.description, "It looks unfinished.", 20) && (found=1))
-            len += snprintf(buf + len, sizeof(buf) - len,
-                            "- Description hasn't been set.\r\n");
-          else if (strncmp(mob->player.description, "   ", 3) && (found=1))
-            len += snprintf(buf + len, sizeof(buf) - len,
-                            "- Description hasn't been formatted. (/fi)\r\n");
-        }
+      if (GET_DAMROLL(mob)>MAX_DAMROLL_ALLOWED && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Damroll of %d is too high (limit: %d)\r\n",
+                        GET_DAMROLL(mob), MAX_DAMROLL_ALLOWED);
 
-        if (GET_LEVEL(mob)>MAX_LEVEL_ALLOWED && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Is level %d (limit: 1-%d)\r\n",
-                          GET_LEVEL(mob), MAX_LEVEL_ALLOWED);
+      if (GET_HITROLL(mob)>MAX_HITROLL_ALLOWED && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Hitroll of %d is too high (limit: %d)\r\n",
+                        GET_HITROLL(mob), MAX_HITROLL_ALLOWED);
 
-        if (GET_DAMROLL(mob)>MAX_DAMROLL_ALLOWED && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Damroll of %d is too high (limit: %d)\r\n",
-                          GET_DAMROLL(mob), MAX_DAMROLL_ALLOWED);
+      /* avg. dam including damroll per round of combat */
+      avg_dam = (((mob->mob_specials.damsizedice / 2.0) * mob->mob_specials.damnodice)+GET_DAMROLL(mob));
+      if (avg_dam>MAX_MOB_DAM_ALLOWED && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- average damage of %4.1f is too high (limit: %d)\r\n",
+                        avg_dam, MAX_MOB_DAM_ALLOWED);
 
-        if (GET_HITROLL(mob)>MAX_HITROLL_ALLOWED && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Hitroll of %d is too high (limit: %d)\r\n",
-                          GET_HITROLL(mob), MAX_HITROLL_ALLOWED);
+      if (mob->mob_specials.damsizedice == 1 &&
+          mob->mob_specials.damnodice == 1 &&
+          GET_LEVEL(mob) == 0 &&
+          (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Needs to be fixed - %sAutogenerate!%s\r\n", CCYEL(ch, C_NRM), CCNRM(ch, C_NRM));
 
-        /* avg. dam including damroll per round of combat */
-        avg_dam = (((mob->mob_specials.damsizedice / 2.0) * mob->mob_specials.damnodice)+GET_DAMROLL(mob));
-        if (avg_dam>MAX_MOB_DAM_ALLOWED && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- average damage of %4.1f is too high (limit: %d)\r\n",
-                          avg_dam, MAX_MOB_DAM_ALLOWED);
+      if (MOB_FLAGGED(mob, MOB_AGGRESSIVE) && (MOB_FLAGGED(mob, MOB_AGGR_GOOD) || MOB_FLAGGED(mob, MOB_AGGR_EVIL) || MOB_FLAGGED(mob, MOB_AGGR_NEUTRAL)) && (found=1))
+   len += snprintf(buf + len, sizeof(buf) - len,
+        "- Both aggresive and agressive to align.\r\n");
 
-        if (mob->mob_specials.damsizedice == 1 &&
-            mob->mob_specials.damnodice == 1 &&
-            GET_LEVEL(mob) == 0 &&
-            (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Needs to be fixed - %sAutogenerate!%s\r\n", CCYEL(ch, C_NRM), CCNRM(ch, C_NRM));
+      if ((GET_GOLD(mob) > MAX_MOB_GOLD_ALLOWED) && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Set to %d Gold (limit : %d).\r\n",
+                                GET_GOLD(mob),
+                                MAX_MOB_GOLD_ALLOWED);
 
-        if (MOB_FLAGGED(mob, MOB_AGGRESSIVE) && (MOB_FLAGGED(mob, MOB_AGGR_GOOD) || MOB_FLAGGED(mob, MOB_AGGR_EVIL) || MOB_FLAGGED(mob, MOB_AGGR_NEUTRAL)) && (found=1))
-	 len += snprintf(buf + len, sizeof(buf) - len,
-          "- Both aggresive and agressive to align.\r\n");
-
-        if ((GET_GOLD(mob) > MAX_MOB_GOLD_ALLOWED) && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Set to %d Gold (limit : %d).\r\n",
-                                  GET_GOLD(mob),
-                                  MAX_MOB_GOLD_ALLOWED);
-
-        if (GET_EXP(mob)>MAX_EXP_ALLOWED && (found=1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Has %d experience (limit: %d)\r\n",
-                              GET_EXP(mob), MAX_EXP_ALLOWED);
-        if ((AFF_FLAGGED(mob, AFF_CHARM) || AFF_FLAGGED(mob, AFF_POISON)) && (found = 1))
-	  len += snprintf(buf + len, sizeof(buf) - len,
-                          "- Has illegal affection bits set (%s %s)\r\n",
-                              AFF_FLAGGED(mob, AFF_CHARM) ? "CHARM" : "",
-                              AFF_FLAGGED(mob, AFF_POISON) ? "POISON" : "");
+      if (GET_EXP(mob)>MAX_EXP_ALLOWED && (found=1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Has %d experience (limit: %d)\r\n",
+                            GET_EXP(mob), MAX_EXP_ALLOWED);
+      if ((AFF_FLAGGED(mob, AFF_CHARM) || AFF_FLAGGED(mob, AFF_POISON)) && (found = 1))
+    len += snprintf(buf + len, sizeof(buf) - len,
+                        "- Has illegal affection bits set (%s %s)\r\n",
+                            AFF_FLAGGED(mob, AFF_CHARM) ? "CHARM" : "",
+                            AFF_FLAGGED(mob, AFF_POISON) ? "POISON" : "");
 
 
-        if (!MOB_FLAGGED(mob, MOB_SENTINEL) && !MOB_FLAGGED(mob, MOB_STAY_ZONE) && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                            "- Neither SENTINEL nor STAY_ZONE bits set.\r\n");
+      if (!MOB_FLAGGED(mob, MOB_SENTINEL) && !MOB_FLAGGED(mob, MOB_STAY_ZONE) && (found = 1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                          "- Neither SENTINEL nor STAY_ZONE bits set.\r\n");
 
-        if (MOB_FLAGGED(mob, MOB_SPEC) && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                            "- SPEC flag needs to be removed.\r\n");
+      if (MOB_FLAGGED(mob, MOB_SPEC) && (found = 1))
+        len += snprintf(buf + len, sizeof(buf) - len,
+                          "- SPEC flag needs to be removed.\r\n");
 
-          /* Additional mob checks.*/
-          if (found) {
-            send_to_char(ch,
-                    "%s[%5d]%s %-30s: %s\r\n",
-                    CCCYN(ch, C_NRM), GET_MOB_VNUM(mob),
-                    CCYEL(ch, C_NRM), GET_NAME(mob),
-                    CCNRM(ch, C_NRM));
-            send_to_char(ch, "%s", buf);
-          }
-          /* reset buffers and found flag */
-          strcpy(buf, "");
-          found = 0;
-          len = 0;
-        }   /* mob is in zone */
-    }  /* check mobs */
+      /* Additional mob checks.*/
+      if (found) {
+        send_to_char(ch,
+                "%s[%5d]%s %-30s: %s\r\n",
+                CCCYN(ch, C_NRM), GET_MOB_VNUM(mob),
+                CCYEL(ch, C_NRM), GET_NAME(mob),
+                CCNRM(ch, C_NRM));
+        send_to_char(ch, "%s", buf);
+      }
+      /* reset buffers and found flag */
+      strcpy(buf, "");
+      found = 0;
+      len = 0;
+    }   /* mob is in zone */
+  }  /* check mobs */
 
  /* Check objects */
   send_to_char(ch, "\r\nChecking Objects for limits...\r\n");
@@ -3959,15 +3959,15 @@ static void obj_checkload(struct char_data *ch, obj_vnum ovnum)
                              mob_proto[lastmob_r].player.short_descr,
                              mob_index[lastmob_r].vnum,
                              ZCMD2.arg2);
-            break;
-          case 'R': /* rem obj from room */
-            lastroom_v = world[ZCMD2.arg1].number;
-            lastroom_r = ZCMD2.arg1;
-            if (ZCMD2.arg2 == ornum)
-              send_to_char(ch, "  [%5d] %s (Removed from room)\r\n",
-                               lastroom_v,
-                               world[lastroom_r].name);
-            break;
+          break;
+        case 'R': /* rem obj from room */
+          lastroom_v = world[ZCMD2.arg1].number;
+          lastroom_r = ZCMD2.arg1;
+          if (ZCMD2.arg2 == ornum)
+            send_to_char(ch, "  [%5d] %s (Removed from room)\r\n",
+                             lastroom_v,
+                             world[lastroom_r].name);
+          break;
       }/* switch */
     } /*for cmd_no......*/
   }  /*for zone...*/

--- a/src/aedit.c
+++ b/src/aedit.c
@@ -42,7 +42,7 @@ ACMD(do_oasis_aedit)
   if (IS_NPC(ch) || !ch->desc || STATE(ch->desc) != CON_PLAYING)
     return;
     
-    if (CONFIG_NEW_SOCIALS == 0) {
+  if (CONFIG_NEW_SOCIALS == 0) {
     send_to_char(ch, "Socials cannot be edited at the moment.\r\n");
     return;
   }

--- a/src/dg_olc.c
+++ b/src/dg_olc.c
@@ -496,52 +496,53 @@ void trigedit_parse(struct descriptor_data *d, char *arg)
            }
            write_to_output(d, "Do you wish to save your changes? : ");
            OLC_MODE(d) = TRIGEDIT_CONFIRM_SAVESTRING;
-         } else
+         } else {
            cleanup_olc(d, CLEANUP_ALL);
-           return;
-         case '1':
-           OLC_MODE(d) = TRIGEDIT_NAME;
-           write_to_output(d, "Name: ");
-           break;
-         case '2':
-           OLC_MODE(d) = TRIGEDIT_INTENDED;
-           write_to_output(d, "0: Mobiles, 1: Objects, 2: Rooms: ");
-           break;
-         case '3':
-           OLC_MODE(d) = TRIGEDIT_TYPES;
-           trigedit_disp_types(d);
-           break;
-         case '4':
-           OLC_MODE(d) = TRIGEDIT_NARG;
-           write_to_output(d, "Numeric argument: ");
-           break;
-         case '5':
-           OLC_MODE(d) = TRIGEDIT_ARGUMENT;
-           write_to_output(d, "Argument: ");
-           break;
-         case '6':
-           OLC_MODE(d) = TRIGEDIT_COMMANDS;
-           write_to_output(d, "Enter trigger commands: (/s saves /h for help)\r\n\r\n");
-           d->backstr = NULL;
-           if (OLC_STORAGE(d)) {
-             clear_screen(d);
-             script_syntax_highlighting(d, OLC_STORAGE(d));
-             d->backstr = strdup(OLC_STORAGE(d));
-           }
-           d->str = &OLC_STORAGE(d);
-           d->max_str = MAX_CMD_LENGTH;
-           d->mail_to = 0;
-           OLC_VAL(d) = 1;
+         }
+         return;
+       case '1':
+         OLC_MODE(d) = TRIGEDIT_NAME;
+         write_to_output(d, "Name: ");
+         break;
+       case '2':
+         OLC_MODE(d) = TRIGEDIT_INTENDED;
+         write_to_output(d, "0: Mobiles, 1: Objects, 2: Rooms: ");
+         break;
+       case '3':
+         OLC_MODE(d) = TRIGEDIT_TYPES;
+         trigedit_disp_types(d);
+         break;
+       case '4':
+         OLC_MODE(d) = TRIGEDIT_NARG;
+         write_to_output(d, "Numeric argument: ");
+         break;
+       case '5':
+         OLC_MODE(d) = TRIGEDIT_ARGUMENT;
+         write_to_output(d, "Argument: ");
+         break;
+       case '6':
+         OLC_MODE(d) = TRIGEDIT_COMMANDS;
+         write_to_output(d, "Enter trigger commands: (/s saves /h for help)\r\n\r\n");
+         d->backstr = NULL;
+         if (OLC_STORAGE(d)) {
+           clear_screen(d);
+           script_syntax_highlighting(d, OLC_STORAGE(d));
+           d->backstr = strdup(OLC_STORAGE(d));
+         }
+         d->str = &OLC_STORAGE(d);
+         d->max_str = MAX_CMD_LENGTH;
+         d->mail_to = 0;
+         OLC_VAL(d) = 1;
 
-           break;
-         case 'w':
-         case 'W':
-           write_to_output(d, "Copy what trigger? ");
-           OLC_MODE(d) = TRIGEDIT_COPY;
-           break;
-         default:
-           trigedit_disp_menu(d);
-           return;
+         break;
+       case 'w':
+       case 'W':
+         write_to_output(d, "Copy what trigger? ");
+         OLC_MODE(d) = TRIGEDIT_COPY;
+         break;
+       default:
+         trigedit_disp_menu(d);
+         return;
      }
      return;
 
@@ -552,7 +553,7 @@ void trigedit_parse(struct descriptor_data *d, char *arg)
           mudlog(CMP, MAX(LVL_BUILDER, GET_INVIS_LEV(d->character)), TRUE,
                  "OLC: %s edits trigger %d", GET_NAME(d->character),
                  OLC_NUM(d));
-          /* fall through */
+          /* no break - fall through */
         case 'n':
           cleanup_olc(d, CLEANUP_ALL);
           return;

--- a/src/prefedit.c
+++ b/src/prefedit.c
@@ -937,11 +937,12 @@ ACMD(do_oasis_prefedit)
   for (d = descriptor_list; d; d = d->next) {
     if (STATE(d) == CON_PREFEDIT) {
       if (d->olc && OLC_PREFS(d)->ch == vict) {
-        if (ch == vict)
+        if (ch == vict) {
           send_to_char(ch, "Your preferences are currently being edited by %s.\r\n", PERS(d->character, ch));
-        else
+        } else {
           sprintf(buf, "$S$u preferences are currently being edited by %s.", PERS(d->character, ch));
           act(buf, FALSE, ch, 0, vict, TO_CHAR);
+        }
         return;
       }
     }

--- a/src/sedit.c
+++ b/src/sedit.c
@@ -464,7 +464,7 @@ void sedit_parse(struct descriptor_data *d, char *arg)
       cleanup_olc(d, CLEANUP_ALL);
       return;
     default:
-     write_to_output(d, "Invalid choice!\r\nDo you wish to save your changes? : ");
+      write_to_output(d, "Invalid choice!\r\nDo you wish to save your changes? : ");
       return;
     }
 
@@ -739,12 +739,12 @@ void sedit_parse(struct descriptor_data *d, char *arg)
   case SEDIT_NEW_ROOM:
     if ((i = atoi(arg)) != -1)
       if ((i = real_room(i)) == NOWHERE) {
-	write_to_output(d, "That room does not exist, try again : ");
-	return;
+        write_to_output(d, "That room does not exist, try again : ");
+        return;
       }
     if (i >= 0)
       add_shop_to_int_list(&(S_ROOMS(OLC_SHOP(d))), atoi(arg));
-      sedit_rooms_menu(d);
+    sedit_rooms_menu(d);
     return;
   case SEDIT_DELETE_ROOM:
     remove_shop_from_int_list(&(S_ROOMS(OLC_SHOP(d))), atoi(arg));

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -406,8 +406,8 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
   case ITEM_POTION:
     tch = ch;
 
-  if (!consume_otrigger(obj, ch, OCMD_QUAFF))  /* check trigger */
-    return;
+    if (!consume_otrigger(obj, ch, OCMD_QUAFF))  /* check trigger */
+      return;
 
     act("You quaff $p.", FALSE, ch, obj, NULL, TO_CHAR);
     if (obj->action_description)


### PR DESCRIPTION
Removed warnings about possible misunderstandings due to layout. A couple of minor refactorings to remove some suspicious semicolons.